### PR TITLE
Days in monthView are not translated

### DIFF
--- a/src/views/monthView.ts
+++ b/src/views/monthView.ts
@@ -44,7 +44,7 @@ export default class MonthView implements IView {
 		// object to array - see https://github.com/indrimuska/angular-moment-picker/issues/9
 		angular.forEach(rows, (row: IViewItem[]) => (<IViewItem[][]>this.rows).push(row));
 		// render headers
-		this.headers = moment.weekdays().map((d: string, i: number) => moment().locale(this.$scope.locale).startOf('week').add(i, 'day').format('dd'));
+		this.headers = moment.weekdays().map((d: string, i: number) => moment().startOf('week').add(i, 'day').format('dd'));
 		// return title
 		return this.$scope.view.moment.format('MMMM YYYY');
 	}


### PR DESCRIPTION
getting locale from scope is unneccessary, cause translation is always based on moment global local when your are working with day.format for example.